### PR TITLE
Change compiler to icx for proper operation with CMake.

### DIFF
--- a/Publications/Data_Parallel_C++/CMakeLists.txt
+++ b/Publications/Data_Parallel_C++/CMakeLists.txt
@@ -5,32 +5,40 @@
 ##############################################################################
 # This top-level CMakeLists.txt file does not define a project or setup any
 # project-specific build configuration variables. That must be done in each
-# sample project's project-specific CMakeLists.txt file.
+# sample project's project-specific CMakeLists.txt file. It does define some
+# general, global options for compiling and linking.
 #
 # This CMakeLists.txt file finds those subdirectories located immediately
 # below it that contain a CMakeLists.txt file, and adds them to its CMake
 # add_subdirectory() list. All other folders and files are ignored.
 #
-# A build file (e.g., Ninja or Makefile) is generated as a result of running
-# this CMakeLists.txt file. That build file will include targets defined by
-# the project-level CMakeLists.txt files located during the add_subdirectory()
-# scan. To see those build targets, type "make help" at the command-line.
+# A build file (e.g., Ninja, Makefile, etc.) is generated as a result of
+# running this CMakeLists.txt file. That build file will include targets
+# defined by the project-level CMakeLists.txt files located during the
+# add_subdirectory() scan. To see those build targets, type "make help"
+# at the command-line.
 ##############################################################################
 
-cmake_minimum_required(VERSION 3.4 )
+# cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_C_COMPILER icx)
+set(CMAKE_CXX_COMPILER icx)
+
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# Override default compile/link lines
-if(WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -w")
-  set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> /Fo<OBJECT> -c <SOURCE>")
-  set(CMAKE_CXX_CREATE_STATIC_LIBRARY "lib <OBJECTS> /out:<TARGET>")
-  set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-endif()
+
+# set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
+
+# # Override default compile/link lines
+# if(WIN32)
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -w")
+#   set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> /Fo<OBJECT> -c <SOURCE>")
+#   set(CMAKE_CXX_CREATE_STATIC_LIBRARY "lib <OBJECTS> /out:<TARGET>")
+#   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
+# endif()
+
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type selected, default to Release")
     set(CMAKE_BUILD_TYPE "Release" CACHE PATH "Build Type" FORCE)
@@ -65,10 +73,7 @@ function(add_book_sample)
     add_executable(${BOOK_SAMPLE_TARGET} ${BOOK_SAMPLE_SOURCES})
 
     target_compile_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl -fsycl-unnamed-lambda -ferror-limit=1 -Wall -Wpedantic)
-    # Passing -fsycl via target_link_libraries for older versions of CMake:
-    #target_link_options(${BOOK_SAMPLE_TARGET} PRIVATE -fsycl )
     target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE sycl -fsycl )
-
     target_link_libraries(${BOOK_SAMPLE_TARGET} PRIVATE ${BOOK_SAMPLE_LIBS})
 
     if(CMAKE_CONFIGURATION_TYPES)
@@ -108,4 +113,3 @@ find_sample_dirs(${sample_dirs})
 # When done here, CMake will finish the task at hand by recursing through
 # all the folders that were added to the add_subdirectory() list and
 # parsing the CMakeLists.txt files found in those folders.
-


### PR DESCRIPTION
# Existing Sample Changes

Change compiler to icx for proper operation with CMake.

Also, set CMake minimum version to 3.20. Required to make the linker work properly. CMake 3.20 and higher includes proper detection of the Intel compiler toolchain on Windows. CMake 3.20 is also included in the latest version of the Visual Studio tools.

## Description

See above

Fixes Issue# 

N/A

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Tested only on Windows, needs to be retested on Linux, but that was already working, so should not result in any issues. Tested against CMake 3.4 and confirmed that it does not work (icx linker is not properly identified). Also, some of the samples in this group have warnings and errors, which need to be fixed.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
